### PR TITLE
Update installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,9 +6,9 @@ Development Container Manager
 
 ### Installation
 
-* `apt install docker.io docker-compose`
+* Install [Docker Engine](https://docs.docker.com/engine/install)
 * `docker network create devnet`
-* `docker-compose up -d`
+* `docker compose up -d`
 
 ## License
 


### PR DESCRIPTION
# Update installation instructions

## **Description**

Per the [Uninstall old versions](https://docs.docker.com/engine/install/debian/#uninstall-old-versions) section of the Docker Debian installation instructions, the `docker.io` and `docker-compose` packages are "unofficial".

### **Additional context**

## Checklist
- [x] Read our contributing guidelines.
- [x] Used an informative name for this pull request.
